### PR TITLE
remove content-length

### DIFF
--- a/lib/faultline.js
+++ b/lib/faultline.js
@@ -81,7 +81,6 @@ Faultline.prototype.trackDeployment = function(params, cb) {
     body: body,
     timeout: this.timeout,
     headers: {
-      'Content-Length': body.length,
       'Content-Type': 'application/json',
       'X-Api-Key': this.apiKey
     },


### PR DESCRIPTION
以前Content-Lengthにより文字数と文字列のByte数のずれが生じるバグがあり、Content-Lengthを使わないようにしたが、Content-Lengthをなくすのに抜けがあった。